### PR TITLE
Fix dronekit-sitl not detecting windows

### DIFF
--- a/dronekit_sitl_runner/__init__.py
+++ b/dronekit_sitl_runner/__init__.py
@@ -63,7 +63,7 @@ def launch(system, version, args):
 def detect_target():
     if sys.platform == 'darwin':
         return 'osx'
-    if sys.platform == 'windows':
+    if sys.platform.startswith('win'):
         return 'win'
     return 'linux'
 


### PR DESCRIPTION
I was testing while looking at why it wasn't functioning on windows and saw that it thought I was on a linux device. This does not fix the windows bugs but at least now it knows whether windows is being run or not.