### PR TITLE
Add parameters and expand example section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,16 +17,42 @@ List of available commands:
 ```
   dronekit-sitl --list
   dronekit-sitl --reset
-  dronekit-sitl <copter(-version)>
-  dronekit-sitl <plane(-version)>
+  dronekit-sitl <copter(-version)> [parameters]
+  dronekit-sitl <plane(-version)> [parameters]
 ```
+
+The ``--list`` commmand is used to display the available build versions (e.g. `copter-3.4-dev`).
+
+The optional ``parameter`` values are listed below.
+
+| Option | Description |
+|------|----|
+| --home HOME | set home location (lat,lng,alt,yaw) |
+| --model MODEL | set simulation model |
+| --wipe | wipe eeprom and dataflash |
+| --rate RATE | set SITL framerate |
+| --console | use console instead of TCP ports |
+| --instance N | set instance of SITL (adds 10*instance to all port numbers) |
+| --speedup SPEEDUP | set simulation speedup |
+| --gimbal | enable simulated MAVLink gimbal |
+| --autotest-dir | DIR set directory for additional files |
+
 
 ## Examples
 
+The following command might be used to start SITL for build of ``copter-3.4-dev``:
+
 ```
 dronekit-sitl copter-3.4-dev -I0 -S --model quad --home=-35.363261,149.165230,584,353
+```
+
+SITL starts and waits for TCP connections on ``127.0.0.1:5760``. In a second terminal you can spawn an instance of MAVProxy to
+forward messages to UDP ports ``127.0.0.1:14550`` and ``127.0.0.1:14551`` (in the same way as **sim_vehicle.sh**):
+
+```
 mavproxy.py --master tcp:127.0.0.1:5760 --sitl 127.0.0.1:5501 --out 127.0.0.1:14550 --out 127.0.0.1:14551
 ```
+
 
 ## Ardupilot versions available:
 

--- a/README.md
+++ b/README.md
@@ -23,18 +23,20 @@ List of available commands:
 
 The ``--list`` commmand is used to display the available build versions (e.g. `copter-3.4-dev`).
 
-The optional ``parameter`` values are listed below.
+The ``-h`` *parameter* can be passed in the command above to list all the parameters to the build 
+(these are reproduced below).
 
 | Option | Description |
 |------|----|
-| --home HOME | set home location (lat,lng,alt,yaw) |
-| --model MODEL | set simulation model |
-| --wipe | wipe eeprom and dataflash |
-| --rate RATE | set SITL framerate |
-| --console | use console instead of TCP ports |
-| --instance N | set instance of SITL (adds 10*instance to all port numbers) |
-| --speedup SPEEDUP | set simulation speedup |
-| --gimbal | enable simulated MAVLink gimbal |
+| --h | Help (display help for the build - i.e. these parameters) |
+| --home HOME | Set home location (lat,lng,alt,yaw) |
+| --model MODEL | Set simulation model |
+| --wipe | Wipe eeprom and dataflash |
+| --rate RATE | Set SITL framerate |
+| --console | Use console instead of TCP ports |
+| --instance N | Set instance of SITL (adds 10*instance to all port numbers) |
+| --speedup SPEEDUP | Set simulation speedup |
+| --gimbal | Enable simulated MAVLink gimbal |
 | --autotest-dir | DIR set directory for additional files |
 
 


### PR DESCRIPTION
This partially fixes #12 (it would still be good if the parameters could be fetched and displayed using `` dronekit-sitl --help``.

This fixes the example, which was previously ambiguous (not clear what the mavproxy command was doing, or that it needed to be run in a separate terminal)